### PR TITLE
Mandrill banner

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <header class="site-header">
   <nav id="nav" class="sp-menu navbar navbar-default navbar-fixed-top" data-spy="affix" data-offset-top="60">
-    <div id="banner">Hi, Mandrill users! <strong><a href="https://www.sparkpost.com/blog/mandrill-alternative-sparkpost-survival-guide/">Let us help you with the switch.</a></strong></div>
+    <div id="banner">Hi, Mandrill users! <strong><a href="https://www.sparkpost.com/mandrill-migration-guide">Let us help you with the switch.</a></strong></div>
     <div class="container">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -119,6 +119,6 @@ body {
 
 .page-api-docs {
   iframe {
-    margin-top: 26px;
+    margin-top: 58px;
   }
 }

--- a/_sass/_navbar.scss
+++ b/_sass/_navbar.scss
@@ -9,6 +9,7 @@
   background: $c-blue;
   text-align: center;
   color: $c-white;
+  font-size: 16px;
 }
 
 #banner a {


### PR DESCRIPTION
Made three changes:
- Changed the in the banner from Ewan's blog post to the same link www.sparkpost.com is using since there is some more information available there.
- Bumped up the size of the font in the banner. For me at least it was looking quite small.
- Changed the top margin of the iframe in which the API code panel appears. This seems to have fixed the problem described in [Slack by Jose][1] whereby the top was chopped off.

[1]: https://msys.slack.com/archives/dev-relations/p1456808711000968