### PR TITLE
Disabled JavaScript code examples

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -8,7 +8,12 @@ class: api-docs
   var embed = new Apiary.Embed({
     subdomain: 'sparkpostapi',
     header: '.sp-menu',
-
+    
+    codeExamples: {
+      // http://embed.apiary.io/api-reference.html#code-examples
+      javaScript: false
+    },
+    
     preferences: {
       collapseMachineColumnByDefault: true,
       fluidHumanColumn: true,


### PR DESCRIPTION
Will help to avoid encouraging folks to use client-side JS with our API when they won't be able to because of security and CORS settings.