### PR TITLE
Making the current docs easier to use today, until new docs are ready

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <header class="site-header">
-  <nav id="nav" class="sp-menu navbar navbar-default navbar-fixed-top" data-spy="affix" data-offset-top="60">
+  <nav id="nav" class="sp-menu navbar navbar-default">
     <div class="nav-banner">Hi, Mandrill users! <a href="https://www.sparkpost.com/mandrill-migration-guide">Let us help you with the switch.</a></div>
     <div class="container">
       <div class="navbar-header">

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -3,7 +3,6 @@
 // --------------------------------------------------
 
 body {
-  padding-top: 120px;
   font-weight: 300;
 }
 
@@ -122,8 +121,22 @@ body {
 // -------------------------
 
 .page-api-docs {
+  .site-header {
+
+    .navbar {
+      margin-bottom: 0;
+
+      .nav-banner {
+        display: none;
+      }
+    }
+  }
+
   iframe {
-    margin-top: 58px;
+    // margin-top: 58px;
+  }
+  footer {
+    display: none;
   }
 }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -2,6 +2,11 @@
 // General layout items
 // --------------------------------------------------
 
+html {
+  /* To match the footer for vertically short pages, avoids nasty white stripe below footer */
+  background-color: $c-sp-gray;
+}
+
 body {
   font-weight: 300;
 }
@@ -36,7 +41,7 @@ body {
 }
 
 .row-dark {
-  background-color: lighten($c-sp-gray, 4%);
+  background-color: $c-sp-gray;
   color: $c-white;
   padding-bottom: 20px;
 }

--- a/_sass/_navbar.scss
+++ b/_sass/_navbar.scss
@@ -85,6 +85,11 @@
 
 }
 
+/* Hack to get around the transparency applied in media queries which accidentally has more specificity because CSS ugh */
+.site-header .navbar {
+  background-color: $c-orange;
+}
+
 .navbar-default {
   .navbar-toggle {
     background-color: $c-orange;

--- a/_sass/_navbar.scss
+++ b/_sass/_navbar.scss
@@ -25,11 +25,11 @@
   transition-timing-function: ease-out;
   background-color: $c-orange;
   border: none;
-  visibility: hidden;
   font-family: $font-family-gotham;
   font-weight: 500;
   font-style: normal;
   font-size: $font-size-base * .857142857; // 12px
+  border-radius: 0px;
 
   @media screen and (min-width: $screen-sm-min) {
     .page-home &,


### PR DESCRIPTION
Did a few things to make the docs more usable while we wait for the new ones:
* Unfixed the header (everywhere, in fact ... maybe we can revisit this with Rich Guy later to see what's best but for now this was the easiest way to fix this issue)
* Removed the Mandrill bar from the API docs page only
* Hid the footer on the API docs page only -- nobody actually intends to get all the way to the bottom of this page, but if you scroll the nav far enough the footer appears and gets in the way big time, not necessary to have the footer on this page imo