### PR TITLE
docs: document empty list_id support for suppression DELETE endpoint

### DIFF
--- a/content/api/suppression-list.apib
+++ b/content/api/suppression-list.apib
@@ -246,9 +246,10 @@ If your account has subaccounts, please provide the `X-MSYS-SUBACCOUNT` header w
 
 ##### Deleting from mailing lists
 
-Use the `list_id` query parameter to delete the suppression specifically from that mailing list.
+Use the `list_id` query parameter to control which suppression entries are deleted:
 - Use `?list_id=newsletter-weekly.example1.com` to delete the suppression from a specific mailing list.
-- Omit the parameter to delete the suppression across all mailing lists (account-wide).
+- Use `?list_id=` (empty value) to delete only the account-level suppression entry (not bound to any mailing list).
+- Omit the parameter to delete **all** suppression entries for the recipient (account-level and all list-specific).
 
 
 + Data Structure


### PR DESCRIPTION
## Summary

- Documents the new `?list_id=` (empty value) behavior on the suppression DELETE endpoint, as implemented in SparkPost/suppressions#144
- Clarifies the three `list_id` query parameter behaviors: specific list, empty (account-level only), and omitted (delete all)

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change clarifying query parameter semantics; no runtime behavior or security-sensitive code is modified.
> 
> **Overview**
> Clarifies `DELETE /v1/suppression-list/{recipient}` semantics for the `list_id` query param, distinguishing **three** behaviors: specific `list_id` deletes that list’s suppression, empty `?list_id=` deletes only the account-level entry, and omitting `list_id` deletes *all* suppression entries for the recipient.
> 
> Adds corresponding documentation for the delete request body `type` parameter in the endpoint section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ddb220e67b63abe8d530f2ac5d449ace2d18d6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->