### PR TITLE
Disable Sentry CSP reporting

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -62,8 +62,6 @@
       'self';
     worker-src
       'none';
-    report-uri
-      https://o113111.ingest.sentry.io/api/4504169636823040/security/?sentry_key=b0ad7185212c4ea689a404b1b2d0eff5
     '''
 
 # Run `npm run publish` to re-index in algolia


### PR DESCRIPTION
## Summary
- Remove Sentry `report-uri` from the Content-Security-Policy header in `netlify.toml`

## Test plan
- [ ] Verify site deploys and loads without CSP errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that stops CSP violation reports from being sent to Sentry; could reduce visibility into real CSP issues.
> 
> **Overview**
> Disables Sentry CSP reporting by removing the `report-uri` directive from the `Content-Security-Policy` header in `netlify.toml`, so CSP violations are no longer posted to Sentry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aef6fed3354f739bafde25242cb5d36e820d8d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->