### PR TITLE
fix: remove unsupported list_id param from Search Suppressions docs

### DIFF
--- a/content/api/suppression-list.apib
+++ b/content/api/suppression-list.apib
@@ -294,7 +294,7 @@ Use the `list_id` query parameter to control which suppression entries are delet
         }
 
 
-### Search Suppressions [GET /v1/suppression-list{?to,from,domain,sources,types,description,description_strict,list_id,cursor,per_page,page,sort}]
+### Search Suppressions [GET /v1/suppression-list{?to,from,domain,sources,types,description,description_strict,cursor,per_page,page,sort}]
 
 Perform a filtered search for entries in your suppression list. Returns an array of suppression objects.
 
@@ -306,9 +306,8 @@ Perform a filtered search for entries in your suppression list. Returns an array
     + sources: `Bounce%20Rule,Manually%20Added` (list, optional) - Sources to match in the search, i.e. entries that were added by this source.
     + types: `transactional` (list, optional) - Types of suppressions to match in the search, i.e. entries that are `transactional` or `non_transactional`.
     + description (string, optional) - String to match in suppression descriptions.
-    + description_strict (boolean, optional) - A complementary field to description. When set to true, will match the exact content in the search description, alternatively will fetch all combination of results in the description. 
+    + description_strict (boolean, optional) - A complementary field to description. When set to true, will match the exact content in the search description, alternatively will fetch all combination of results in the description.
         + Default: false
-    + list_id (string, optional) - Filter by mailing list identifier to return only list-specific suppressions.
     + cursor (string, optional) - The results cursor location to return, to start paging with cursor, use the value of 'initial'. When cursor is provided the `page` parameter is ignored.
     + per_page (number, optional) - Maximum number of results to return per page. Must be between 1 and 10,000.
         + Default: 1000


### PR DESCRIPTION
## Summary

The Search Suppressions endpoint (`GET /v1/suppression-list`) was documented as accepting a `list_id` query parameter, but the suppressions service does not validate or read it on this path — passing it has no effect on the results.

Verified against `suppressions/packages/api`:
- `lib/validator/suppressions-validator.js` — the validator config used by the search route has no `list_id` entry.
- `resources/utils.js:514` — `getParamsForListReq` destructures `{ from, to, recipient, sources, domain, description }` from `req.query`; `list_id` is never read.

`list_id` is still supported on the per-recipient PUT, GET, and DELETE endpoints, so only the Search Suppressions docs needed correction.

Closes #579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in the API blueprint; no runtime or auth behavior is modified.
> 
> **Overview**
> Aligns **Search Suppressions** (`GET /v1/suppression-list`) documentation with actual API behavior by dropping the **`list_id`** query parameter from the route template and parameter list. That filter was documented but is not applied on search, so clients could assume list-scoped filtering that never happens.
> 
> **`list_id`** documentation on per-recipient create/update, retrieve, and delete flows is unchanged. A small whitespace cleanup on the **`description_strict`** parameter line is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5df357422f29e450d5c46014ad12f6a3cf6a96b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->