### PR TITLE
docs: document list_id query param on Search Suppressions

### DIFF
--- a/content/api/suppression-list.apib
+++ b/content/api/suppression-list.apib
@@ -294,9 +294,17 @@ Use the `list_id` query parameter to control which suppression entries are delet
         }
 
 
-### Search Suppressions [GET /v1/suppression-list{?to,from,domain,sources,types,description,description_strict,cursor,per_page,page,sort}]
+### Search Suppressions [GET /v1/suppression-list{?to,from,domain,sources,types,description,description_strict,list_id,cursor,per_page,page,sort}]
 
 Perform a filtered search for entries in your suppression list. Returns an array of suppression objects.
+
+Use the `list_id` query parameter to control which suppression entries are returned:
+
+- Use `?list_id=newsletter-weekly.example1.com` to return only suppressions for that specific mailing list.
+- Use `?list_id=` (empty value) to return only account-level suppression entries (not bound to any mailing list).
+- Omit the parameter to return **all** suppression entries (account-level and all list-specific).
+
+When provided with a non-empty value, `list_id` must be RFC 2919 compliant (alphanumeric, hyphens, underscores, and dots; no leading, trailing, or consecutive dots; 1-255 characters). Invalid values return `400`.
 
 + Parameters
     + to (string, optional) - Date the suppressions were last updated, in the format of `YYYY-MM-DDTHH:mm:ssZ`.
@@ -308,6 +316,7 @@ Perform a filtered search for entries in your suppression list. Returns an array
     + description (string, optional) - String to match in suppression descriptions.
     + description_strict (boolean, optional) - A complementary field to description. When set to true, will match the exact content in the search description, alternatively will fetch all combination of results in the description.
         + Default: false
+    + list_id: `newsletter-weekly.example1.com` (string, optional) - Mailing list identifier. If provided with a non-empty value, returns only suppressions for that specific mailing list. If provided with an empty value (`list_id=`), returns only account-level suppressions. If omitted, returns all suppressions.
     + cursor (string, optional) - The results cursor location to return, to start paging with cursor, use the value of 'initial'. When cursor is provided the `page` parameter is ignored.
     + per_page (number, optional) - Maximum number of results to return per page. Must be between 1 and 10,000.
         + Default: 1000


### PR DESCRIPTION
## Summary

Documents the `list_id` query parameter on `GET /v1/suppression-list`, which now supports the same three modes already exposed by the DELETE endpoint:

| Request | Behavior |
|---------|----------|
| `?list_id=newsletter-weekly.example1.com` | Returns only suppressions for that specific mailing list |
| `?list_id=` (empty value) | Returns only account-level suppressions (no `list_id` field) |
| no `list_id` param | Returns all suppression entries (existing behavior) |
| `?list_id=<invalid format>` | `400` with RFC 2919 validation error |

This reverses #580, which removed the parameter from the docs when the API didn't yet implement it. The implementation has since shipped (SparkPost/suppressions#148, SparkPost/suppressions#150) and was verified end-to-end on stg and prd before this docs update.

The existing Search Suppressions response example already mixes account-level and list-specific suppressions, so it illustrates the modes without further edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to the suppression list API spec; no runtime or implementation changes in this PR.
> 
> **Overview**
> Documents **`list_id`** on **`GET /v1/suppression-list`** so search filtering matches the behavior already described for **DELETE**.
> 
> The route template and parameters now include **`list_id`**, with prose for three modes: a specific mailing list, account-level only via an empty value, or all entries when omitted. Non-empty values must be **RFC 2919** compliant; invalid values return **`400`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af5162901db437ba59098f37166381be8a9cb911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->