### PR TITLE
fix: render list_id search parameter cleanly

### DIFF
--- a/content/api/suppression-list.apib
+++ b/content/api/suppression-list.apib
@@ -316,7 +316,7 @@ When provided with a non-empty value, `list_id` must be RFC 2919 compliant (alph
     + description (string, optional) - String to match in suppression descriptions.
     + description_strict (boolean, optional) - A complementary field to description. When set to true, will match the exact content in the search description, alternatively will fetch all combination of results in the description.
         + Default: false
-    + list_id: `newsletter-weekly.example1.com` (string, optional) - Mailing list identifier. If provided with a non-empty value, returns only suppressions for that specific mailing list. If provided with an empty value (`list_id=`), returns only account-level suppressions. If omitted, returns all suppressions.
+    + list_id: `newsletter-weekly.example1.com` (string, optional) - Mailing list identifier. If provided, returns suppressions only for that specific mailing list. If omitted, returns all suppressions. See the description above for the empty-value behavior.
     + cursor (string, optional) - The results cursor location to return, to start paging with cursor, use the value of 'initial'. When cursor is provided the `page` parameter is ignored.
     + per_page (number, optional) - Maximum number of results to return per page. Must be between 1 and 10,000.
         + Default: 1000


### PR DESCRIPTION
## Summary

PR #581 documented the new `list_id` search query parameter, but the rendered output on developers.sparkpost.com breaks the parameter description mid-sentence:

> list_id: \`newsletter-weekly.example1.com\` (string, optional) - Mailing list identifier. If provided with a non-empty value, returns only suppressions for that specific mailing list. If provided with an empty value (\`list_id=\`), returns only account
>
> **string required**
>
> level suppressions. If omitted, returns all suppressions.

Aglio/MSON parses the embedded `(\`list_id=\`)` parenthetical inside the description as another attribute block, which is why "string required" appears as a phantom heading between the words "account" and "level".

## Fix

Trim the parameter description to the shape already used by the DELETE endpoint's `list_id` parameter (line 263 of `suppression-list.apib`): a single short sentence covering the provided/omitted cases, with a pointer up to the prose block that already documents the empty-value mode in full.

No information is lost — the three modes (specific list_id, empty value for account-level, omitted for all) are still spelled out in the prose section above the parameters list, complete with examples and the RFC 2919 validation note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit in an API blueprint file; no runtime or API behavior changes.
> 
> **Overview**
> Fixes broken **Search Suppressions** docs for the `list_id` query parameter on developers.sparkpost.com. The previous description embedded `` `list_id=` `` in the parameter text, which Aglio/MSON mis-parsed as a second attribute and split the sentence with a phantom **string required** block.
> 
> The `list_id` parameter line is rewritten to match the shorter style used on the DELETE endpoint: provided vs omitted behavior in one sentence, with a reference to the prose above for empty-value (`list_id=`) behavior. No API behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649ce3a3d1be3193e1c5601a57647c6cb1ad74cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->