### PR TITLE
docs: document tracking_domain field on Create a Transmission

### DIFF
--- a/content/api/transmissions.apib
+++ b/content/api/transmissions.apib
@@ -93,6 +93,8 @@ You can create a transmission in a number of ways.
     + substitution_data (object) - Object of data passed to the [template language](/api/template-language/) in the content. Recipient substitution data takes precedence over transmission substitution data. Maximum length - 100KB
     + return_path (string)
         Email address to use for envelope FROM. The domain of the `return_path` address must be a [CNAME-verified sending domain](sending-domains.html#header-using-a-sending-domain-as-a-bounce-domain).  The local part of the `return_path` address will be overwritten by SparkPost.<br><br>For <a href="https://www.sparkpost.com/enterprise-email/"><span class="label label-warning"><strong>Enterprise</strong></span></a> accounts, the `return_path` may be any valid email address and the local part in the `return_path` will **not** be overwritten by SparkPost.  To support [Variable Envelope Return Path](https://en.wikipedia.org/wiki/Variable_envelope_return_path) (VERP), this field can be specified in each recipient object in order to give the recipients unique envelope MAIL FROM addresses.
+    + tracking_domain (string)
+        The [tracking domain](/api/tracking-domains/) used to wrap engagement-tracked links (opens and clicks) in this transmission. When provided, this value overrides the tracking domain associated with the sending domain, as well as the subaccount and account defaults. The domain must be a verified tracking domain owned by the account (or by the subaccount, when sending as a subaccount). An unconfigured, unverified, or non-compliant value will be rejected synchronously with a 400 response.
 + Sample
 
     ```


### PR DESCRIPTION
## Summary

**Documents the new `tracking_domain` field on the Create a Transmission request body.**

The transmissions API recently added support for an injection-level `tracking_domain` that overrides the tracking domain associated with the sending domain. Customers need this documented to discover and use the field correctly.

## Test plan
- [ ] `npm run develop` and confirm the new field renders under Create a Transmission > Request Body, immediately after `return_path`
- [ ] Verify the link to `/api/tracking-domains/` resolves correctly
- [ ] Confirm no other sections of the transmissions API page regress

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit edea686931ee881f73f2d200fb2050052600b270. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->