### PR TITLE
docs: update sparkpost.com/docs links to docs.sparkpost.com subdomain

### DIFF
--- a/content/pages/index.js
+++ b/content/pages/index.js
@@ -335,7 +335,7 @@ const IndexPage = props => {
               >
                 Start sending with the most powerful email platform. Check out
                 the{' '}
-                <Link to="https://www.sparkpost.com/docs/getting-started/getting-started-sparkpost/">
+                <Link to="https://docs.sparkpost.com/docs/getting-started/getting-started-sparkpost/">
                   full guide
                 </Link>{' '}
                 to get started.
@@ -360,7 +360,7 @@ const IndexPage = props => {
                     Add the domain you want to send from and verify you own it
                     through DNS settings.
                   </p>
-                  <Link to="https://www.sparkpost.com/docs/getting-started/getting-started-sparkpost/#preparing-your-from-address">
+                  <Link to="https://docs.sparkpost.com/docs/getting-started/getting-started-sparkpost/#preparing-your-from-address">
                     Add a sending domain <i className="fa fa-chevron-right" />
                   </Link>
                 </StartStep>
@@ -373,7 +373,7 @@ const IndexPage = props => {
                     of our official or community supported{' '}
                     <Link to="#client-libraries">client libraries</Link>.
                   </p>
-                  <Link to="https://www.sparkpost.com/docs/getting-started/getting-started-sparkpost/#sending-email">
+                  <Link to="https://docs.sparkpost.com/docs/getting-started/getting-started-sparkpost/#sending-email">
                     Send your first email <i className="fa fa-chevron-right" />
                   </Link>
                 </StartStep>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -120,7 +120,7 @@ export default () => (
           <FooterColumn md={2} sm={4} xs={12}>
             <Header uppercase>Support</Header>
             <List>
-              <Item to="https://www.sparkpost.com/docs/">Help &amp; Docs</Item>
+              <Item to="https://docs.sparkpost.com/docs/">Help &amp; Docs</Item>
               <Item to="https://www.sparkpost.com/report-abuse/">
                 Report Abuse
               </Item>


### PR DESCRIPTION
## Summary
- SparkPost's docs site canonical host moved from `www.sparkpost.com/docs` to `docs.sparkpost.com/docs`. This PR updates the remaining outbound links in `content/pages/index.js` and `src/components/Footer/index.js` that still pointed at the old `www.sparkpost.com/docs` host.
- Mechanical `www.sparkpost.com/docs` → `docs.sparkpost.com/docs` substring replace; no other links touched.

## Test plan
- [ ] Spot-check the homepage and footer links render correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic URL-only changes to external documentation links with no application logic or data handling impact.
> 
> **Overview**
> Updates outbound documentation URLs from **`www.sparkpost.com/docs`** to **`docs.sparkpost.com/docs`** so links match the docs site’s canonical host.
> 
> On the homepage (`content/pages/index.js`), the getting-started **full guide** link and two step links (domain setup and first send) now use the subdomain; anchor paths are unchanged. The footer **Help & Docs** item (`src/components/Footer/index.js`) uses the same host swap. No other links or behavior were modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3462287298f61e056e8b366d7d2f4b31d952596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->