### PR TITLE
docs: fix broken SparkPost Postman collection link

### DIFF
--- a/content/api/index.apib
+++ b/content/api/index.apib
@@ -63,7 +63,7 @@ curl -v \
 
 If you use <a href="https://www.postman.com/" target="_blank">Postman</a> you can click the following button to import the SparkPost API as a collection:
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://god.postman.co/run-collection/ee44dcd644445e8bd864?action=collection%2Fimport)
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://raw.githubusercontent.com/SparkPost/postman-collection/master/collection/sparkpost-api.json.postman_collection.json)
 
 **Environment Setup**
 

--- a/src/components/api/parts/ResourceGroup.js
+++ b/src/components/api/parts/ResourceGroup.js
@@ -27,7 +27,7 @@ const PostmanLink = styled(props => (
     content="Import the SparkPost API as a Postman collection"
   >
     <Link
-      to="https://god.postman.co/run-collection/ee44dcd644445e8bd864?action=collection%2Fimport"
+      to="https://raw.githubusercontent.com/SparkPost/postman-collection/master/collection/sparkpost-api.json.postman_collection.json"
       target="_blank"
     >
       <img src="https://run.pstmn.io/button.svg" alt="Run in Postman" />


### PR DESCRIPTION
## Summary
- The `god.postman.co/run-collection/...` link/button for the SparkPost Postman collection is broken.
- Replaced it with the raw collection JSON on GitHub (`raw.githubusercontent.com/SparkPost/postman-collection/master/collection/sparkpost-api.json.postman_collection.json`), which works both when clicked directly and via Postman's import-by-URL flow.

## Test plan
- [ ] Confirm the new link resolves and downloads valid JSON
- [ ] Confirm the "Run in Postman" button imports the collection cleanly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and external-link-only changes with no runtime API or auth impact.
> 
> **Overview**
> Fixes the broken **Run in Postman** import URL by pointing both the API overview docs and the API reference UI at the hosted collection JSON on GitHub instead of the dead `god.postman.co/run-collection/...` link.
> 
> The markdown in `content/api/index.apib` and the `PostmanLink` in `ResourceGroup.js` now use `https://raw.githubusercontent.com/SparkPost/postman-collection/master/collection/sparkpost-api.json.postman_collection.json`, which supports direct download and Postman import-by-URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85f9559e6369dd2f4fcc6140572df36df9035afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->